### PR TITLE
Removed Copy trait bound on Game::M

### DIFF
--- a/examples/chess/src/main.rs
+++ b/examples/chess/src/main.rs
@@ -24,8 +24,8 @@ impl minimax::Game for Chess {
         }
     }
 
-    fn apply(b: &mut Board, m: ChessMove) -> Option<Board> {
-        Some(b.make_move_new(m))
+    fn apply(b: &mut Board, m: &ChessMove) -> Option<Board> {
+        Some(b.make_move_new(*m))
     }
 
     fn zobrist_hash(b: &Board) -> u64 {
@@ -74,7 +74,7 @@ fn main() {
     while Chess::get_winner(&b).is_none() {
         println!("{}", b);
         match strategy.choose_move(&b) {
-            Some(m) => b = Chess::apply(&mut b, m).unwrap(),
+            Some(m) => b = Chess::apply(&mut b, &m).unwrap(),
             None => break,
         }
     }

--- a/examples/connect4.rs
+++ b/examples/connect4.rs
@@ -128,7 +128,7 @@ impl minimax::Game for Game {
         }
     }
 
-    fn apply(b: &mut Board, place: Place) -> Option<Board> {
+    fn apply(b: &mut Board, place: &Place) -> Option<Board> {
         let mut b = b.clone();
         let col = (b.all_pieces >> place.col_shift()) & COL_MASK;
         let new_piece = (col + 1) << place.col_shift();
@@ -278,7 +278,7 @@ fn main() {
             Some(m) => {
                 let color = if b.reds_move() { "Red" } else { "Yellow" };
                 println!("{} piece in column {}", color, m.col + 1);
-                b = self::Game::apply(&mut b, m).unwrap();
+                b = self::Game::apply(&mut b, &m).unwrap();
             }
             None => break,
         }

--- a/examples/mancala.rs
+++ b/examples/mancala.rs
@@ -43,7 +43,7 @@ impl minimax::Game for Mancala {
         }
     }
 
-    fn apply(board: &mut Board, m: Move) -> Option<Board> {
+    fn apply(board: &mut Board, m: &Move) -> Option<Board> {
         let mut board = board.clone();
         if board.skipped {
             board.skipped = false;
@@ -53,7 +53,7 @@ impl minimax::Game for Mancala {
 
         // Grab the stones.
         let mut player = board.to_move as usize;
-        let mut i = m as usize;
+        let mut i = *m as usize;
         let mut stones = board.pits[player][i];
         board.pits[player][i] = 0;
         // At the beginning of each iteration, it points at the previous pit.
@@ -161,7 +161,7 @@ fn main() {
     while Mancala::get_winner(&board).is_none() {
         println!("{}", board);
         match strategy.choose_move(&board) {
-            Some(m) => board = Mancala::apply(&mut board, m).unwrap(),
+            Some(m) => board = Mancala::apply(&mut board, &m).unwrap(),
             None => break,
         }
     }

--- a/examples/ttt.rs
+++ b/examples/ttt.rs
@@ -152,12 +152,12 @@ impl minimax::Game for Game {
         }
     }
 
-    fn apply(b: &mut Board, m: Place) -> Option<Board> {
+    fn apply(b: &mut Board, m: &Place) -> Option<Board> {
         b.squares[m.i as usize] = b.to_move;
         b.to_move = b.to_move.invert();
         None
     }
-    fn undo(b: &mut Board, m: Place) {
+    fn undo(b: &mut Board, m: &Place) {
         b.squares[m.i as usize] = Square::Empty;
         b.to_move = b.to_move.invert();
     }
@@ -247,7 +247,7 @@ fn main() {
         println!("{}", b);
         let ref mut strategy = strategies[s];
         match strategy.choose_move(&mut b) {
-            Some(m) => self::Game::apply(&mut b, m),
+            Some(m) => self::Game::apply(&mut b, &m),
             None => break,
         };
         s = 1 - s;

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -81,7 +81,7 @@ pub trait Game: Sized {
     /// The type of the game state.
     type S;
     /// The type of game moves.
-    type M: Copy;
+    type M;
 
     /// Generate moves at the given state.
     fn generate_moves(state: &Self::S, moves: &mut Vec<Self::M>);
@@ -96,11 +96,11 @@ pub trait Game: Sized {
     /// ```
     /// struct BigBoard([u8; 4096]);
     /// struct BigMove(u16);
-    /// fn apply(state: &mut BigBoard, m: BigMove) -> Option<BigBoard> {
+    /// fn apply(state: &mut BigBoard, m: &BigMove) -> Option<BigBoard> {
     ///     state.0[m.0 as usize] += 1;
     ///     None
     /// }
-    /// fn undo(state: &mut BigBoard, m: BigMove) {
+    /// fn undo(state: &mut BigBoard, m: &BigMove) {
     ///     state.0[m.0 as usize] -= 1;
     /// }
     /// ```
@@ -109,14 +109,14 @@ pub trait Game: Sized {
     /// ```
     /// struct SmallBoard(u64);
     /// struct SmallMove(u8);
-    /// fn apply(state: &mut SmallBoard, m: SmallMove) -> Option<SmallBoard> {
+    /// fn apply(state: &mut SmallBoard, m: &SmallMove) -> Option<SmallBoard> {
     ///     Some(SmallBoard(state.0 | (1<<m.0)))
     /// }
     /// ```
-    fn apply(state: &mut Self::S, m: Self::M) -> Option<Self::S>;
+    fn apply(state: &mut Self::S, m: &Self::M) -> Option<Self::S>;
 
     /// Undo mutation done in apply, if any.
-    fn undo(_state: &mut Self::S, _m: Self::M) {}
+    fn undo(_state: &mut Self::S, _m: &Self::M) {}
 
     /// Returns `Some(PlayerJustMoved)` or `Some(PlayerToMove)` if there's a winner,
     /// `Some(Draw)` if the state is terminal without a winner, and `None` if

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!         }
 //!     }
 //!
-//!     fn apply(state: &mut War, tug: Tug) -> Option<War> {
+//!     fn apply(state: &mut War, tug: &Tug) -> Option<War> {
 //!         Some(War(state.0 + tug.0))
 //!     }
 //! }

--- a/src/strategies/iterative.rs
+++ b/src/strategies/iterative.rs
@@ -375,7 +375,7 @@ where
 	      self.eval.evaluate(s) >= beta
             {
                 // If we just pass and let the opponent play this position (at reduced depth),
-                let mut nulled = AppliedMove::<E::G>::new(s, null_move);
+                let mut nulled = AppliedMove::<E::G>::new(s, &null_move);
                 let value =
                     -self.negamax(&mut nulled, None, depth - depth_reduction, -beta, -beta + 1)?;
                 // is the result still so good that we shouldn't bother with a full search?
@@ -411,7 +411,7 @@ where
 
         let mut best = WORST_EVAL;
         for m in moves.iter() {
-            let mut new = AppliedMove::<E::G>::new(s, *m);
+            let mut new = AppliedMove::<E::G>::new(s, m);
             let value = -self.noisy_negamax(&mut new, depth - 1, -beta, -alpha)?;
             best = max(best, value);
             alpha = max(alpha, value);
@@ -480,7 +480,7 @@ where
         let mut best_move = moves[0];
         let mut null_window = false;
         for &m in moves.iter() {
-            let mut new = AppliedMove::<E::G>::new(s, m);
+            let mut new = AppliedMove::<E::G>::new(s, &m);
             let value = if null_window {
                 let probe = -self.negamax(&mut new, Some(m), depth - 1, -alpha - 1, -alpha)?;
                 if probe > alpha && probe < beta {
@@ -534,7 +534,7 @@ where
         let mut alpha = WORST_EVAL;
         let beta = BEST_EVAL;
         for value_move in moves.iter_mut() {
-            let mut new = AppliedMove::<E::G>::new(s, value_move.m);
+            let mut new = AppliedMove::<E::G>::new(s, &value_move.m);
             let value = -self.negamax(&mut new, Some(value_move.m), depth - 1, -beta, -alpha)?;
 
             alpha = max(alpha, value);

--- a/src/strategies/negamax.rs
+++ b/src/strategies/negamax.rs
@@ -49,7 +49,7 @@ impl<E: Evaluator> Negamax<E> {
         E::G::generate_moves(s, &mut moves);
         let mut best = WORST_EVAL;
         for m in moves.iter() {
-            let mut new = AppliedMove::<E::G>::new(s, *m);
+            let mut new = AppliedMove::<E::G>::new(s, m);
             let value = -self.negamax(&mut new, depth - 1, -beta, -alpha);
             best = max(best, value);
             alpha = max(alpha, value);
@@ -85,7 +85,7 @@ where
         let mut s_clone = s.clone();
         for &m in moves.iter() {
             // determine value for this move
-            let mut new = AppliedMove::<E::G>::new(&mut s_clone, m);
+            let mut new = AppliedMove::<E::G>::new(&mut s_clone, &m);
             let value = -self.negamax(&mut new, self.max_depth - 1, WORST_EVAL, -best);
             // Strictly better than any move found so far.
             if value > best {

--- a/src/strategies/table.rs
+++ b/src/strategies/table.rs
@@ -126,7 +126,7 @@ pub(super) trait Table<M: Copy> {
             // equivalent upper and lower bounds.
             let m = entry.best_move.unwrap();
             pv.push(m);
-            if let Some(new_state) = G::apply(&mut state, m) {
+            if let Some(new_state) = G::apply(&mut state, &m) {
                 state = new_state;
             }
             hash = G::zobrist_hash(&state);

--- a/src/strategies/util.rs
+++ b/src/strategies/util.rs
@@ -47,7 +47,7 @@ where
             out.push_str("; ");
         }
         out.push_str(move_id::<G>(&state, Some(m)).as_str());
-        if let Some(new_state) = G::apply(&mut state, m) {
+        if let Some(new_state) = G::apply(&mut state, &m) {
             state = new_state;
         }
     }

--- a/src/strategies/ybw.rs
+++ b/src/strategies/ybw.rs
@@ -119,7 +119,7 @@ where
 	      self.eval.evaluate(s) >= beta
             {
                 // If we just pass and let the opponent play this position (at reduced depth),
-                let mut nulled = AppliedMove::<E::G>::new(s, null_move);
+                let mut nulled = AppliedMove::<E::G>::new(s, &null_move);
                 let value =
                     -self.negamax(&mut nulled, None, depth - depth_reduction, -beta, -beta + 1)?;
                 // is the result still so good that we shouldn't bother with a full search?
@@ -156,7 +156,7 @@ where
 
         let mut best = WORST_EVAL;
         for &m in moves.iter() {
-            let mut new = AppliedMove::<E::G>::new(s, m);
+            let mut new = AppliedMove::<E::G>::new(s, &m);
             let value = -self.noisy_negamax(&mut new, depth - 1, -beta, -alpha)?;
             best = max(best, value);
             alpha = max(alpha, value);
@@ -226,7 +226,7 @@ where
 
         // Evaluate first move serially.
         let initial_value = {
-            let mut new = AppliedMove::<E::G>::new(s, first_move);
+            let mut new = AppliedMove::<E::G>::new(s, &first_move);
             -self.negamax(&mut new, Some(first_move), depth - 1, -beta, -alpha)?
         };
         alpha = max(alpha, initial_value);
@@ -239,7 +239,7 @@ where
             let mut best_move = first_move;
             let mut null_window = false;
             for &m in moves[1..].iter() {
-                let mut new = AppliedMove::<E::G>::new(s, m);
+                let mut new = AppliedMove::<E::G>::new(s, &m);
                 let value = if null_window {
                     let probe = -self.negamax(&mut new, Some(m), depth - 1, -alpha - 1, -alpha)?;
                     if probe > alpha && probe < beta {
@@ -279,7 +279,7 @@ where
                 }
 
                 let mut state = s.clone();
-                let mut new = AppliedMove::<E::G>::new(&mut state, m);
+                let mut new = AppliedMove::<E::G>::new(&mut state, &m);
                 let value = if self.opts.null_window_search && initial_alpha > alpha_orig {
                     // TODO: send reference to alpha as neg_beta to children.
                     let probe = -self.negamax(
@@ -492,7 +492,7 @@ where
                 &self.thread_pool,
             );
             let mut state = s.clone();
-            if let Some(new_state) = E::G::apply(&mut state, best_move) {
+            if let Some(new_state) = E::G::apply(&mut state, &best_move) {
                 state = new_state;
             }
             // Launch in threadpool asynchronously.

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,35 +11,35 @@ use rayon::prelude::*;
 use std::default::Default;
 use std::time::Instant;
 
-pub(crate) struct AppliedMove<'a, G: Game> {
+pub(crate) struct AppliedMove<'a, 'b, G: Game> {
     old: &'a mut <G as Game>::S,
     new: Option<<G as Game>::S>,
-    m: <G as Game>::M,
+    m: &'b <G as Game>::M,
 }
 
-impl<'a, G: Game> std::ops::Deref for AppliedMove<'a, G> {
+impl<'a, 'b, G: Game> std::ops::Deref for AppliedMove<'a, 'b, G> {
     type Target = <G as Game>::S;
     fn deref(&self) -> &<G as Game>::S {
         self.new.as_ref().unwrap_or(self.old)
     }
 }
 
-impl<'a, G: Game> std::ops::DerefMut for AppliedMove<'a, G> {
+impl<'a, 'b, G: Game> std::ops::DerefMut for AppliedMove<'a, 'b, G> {
     fn deref_mut(&mut self) -> &mut <G as Game>::S {
         self.new.as_mut().unwrap_or(self.old)
     }
 }
 
-impl<'a, G: Game> Drop for AppliedMove<'a, G> {
+impl<'a, 'b, G: Game> Drop for AppliedMove<'a, 'b, G> {
     fn drop(&mut self) {
-        <G as Game>::undo(self.old, self.m)
+        <G as Game>::undo(self.old, &self.m)
     }
 }
 
-impl<'a, G: Game> AppliedMove<'a, G> {
-    pub(crate) fn new(old: &'a mut <G as Game>::S, m: <G as Game>::M) -> Self {
+impl<'a, 'b, G: Game> AppliedMove<'a, 'b, G> {
+    pub(crate) fn new(old: &'a mut <G as Game>::S, m: &'b <G as Game>::M) -> Self {
         let new = G::apply(old, m);
-        AppliedMove { old, new, m }
+        AppliedMove { old, new, m: m }
     }
 }
 
@@ -68,7 +68,7 @@ where
         let strategy = &mut strategies[s];
         match strategy.choose_move(&state) {
             Some(m) => {
-                if let Some(new_state) = G::apply(&mut state, m) {
+                if let Some(new_state) = G::apply(&mut state, &m) {
                     state = new_state;
                 }
             }
@@ -122,7 +122,7 @@ where
         // Single-thread recurse.
         let mut count = 0;
         for &m in moves.iter() {
-            let mut new = AppliedMove::<G>::new(state, m);
+            let mut new = AppliedMove::<G>::new(state, &m);
             count += perft_recurse::<G>(pool, &mut new, depth - 1, single_thread_cutoff);
         }
         count
@@ -134,7 +134,7 @@ where
             .map(|m| {
                 let mut state = state.clone();
                 let mut pool2 = MovePool::<G::M>::default();
-                if let Some(new_state) = G::apply(&mut state, *m) {
+                if let Some(new_state) = G::apply(&mut state, m) {
                     state = new_state;
                 }
                 perft_recurse::<G>(&mut pool2, &mut state, depth - 1, single_thread_cutoff)

--- a/tests/strategies.rs
+++ b/tests/strategies.rs
@@ -42,7 +42,7 @@ impl<E: Evaluator> PlainNegamax<E> {
         E::G::generate_moves(s, &mut moves);
         let mut best = WORST_EVAL;
         for &m in moves.iter() {
-            let mut new = E::G::apply(s, m).unwrap();
+            let mut new = E::G::apply(s, &m).unwrap();
             let value = -self.negamax(&mut new, depth - 1);
             best = max(best, value);
         }
@@ -63,7 +63,7 @@ where
         let mut best_value = WORST_EVAL;
         let mut s = s.clone();
         for &m in moves.iter() {
-            let mut new = E::G::apply(&mut s, m).unwrap();
+            let mut new = E::G::apply(&mut s, &m).unwrap();
             let value = -self.negamax(&mut new, self.depth - 1);
             if value == best_value {
                 self.best_moves.push(m);
@@ -107,7 +107,7 @@ fn generate_random_state(depth: u8) -> connect4::Board {
         let mut moves = Vec::new();
         connect4::Game::generate_moves(&b, &mut moves);
         let m = moves.choose(&mut rng).unwrap();
-        let next = connect4::Game::apply(&mut b, *m).unwrap();
+        let next = connect4::Game::apply(&mut b, m).unwrap();
         if connect4::Game::get_winner(&next).is_some() {
             // Oops, undo and try again on the next iter.
         } else {
@@ -120,13 +120,13 @@ fn generate_random_state(depth: u8) -> connect4::Board {
 #[test]
 fn test_winning_position() {
     let mut b = connect4::Board::default();
-    b = connect4::Game::apply(&mut b, connect4::Place { col: 2 }).unwrap();
-    b = connect4::Game::apply(&mut b, connect4::Place { col: 3 }).unwrap();
-    b = connect4::Game::apply(&mut b, connect4::Place { col: 2 }).unwrap();
-    b = connect4::Game::apply(&mut b, connect4::Place { col: 3 }).unwrap();
-    b = connect4::Game::apply(&mut b, connect4::Place { col: 2 }).unwrap();
-    b = connect4::Game::apply(&mut b, connect4::Place { col: 3 }).unwrap();
-    b = connect4::Game::apply(&mut b, connect4::Place { col: 2 }).unwrap();
+    b = connect4::Game::apply(&mut b, &connect4::Place { col: 2 }).unwrap();
+    b = connect4::Game::apply(&mut b, &connect4::Place { col: 3 }).unwrap();
+    b = connect4::Game::apply(&mut b, &connect4::Place { col: 2 }).unwrap();
+    b = connect4::Game::apply(&mut b, &connect4::Place { col: 3 }).unwrap();
+    b = connect4::Game::apply(&mut b, &connect4::Place { col: 2 }).unwrap();
+    b = connect4::Game::apply(&mut b, &connect4::Place { col: 3 }).unwrap();
+    b = connect4::Game::apply(&mut b, &connect4::Place { col: 2 }).unwrap();
     assert_eq!(Some(Winner::PlayerJustMoved), connect4::Game::get_winner(&b));
 
     // Make sure none of the strategies die when given a winning position.


### PR DESCRIPTION
to make it easier to implement games with arbitrarily complex moves where heap alocation is neccessary and therefore the copy trait cannot be easily implemented (if at all)